### PR TITLE
Fix includes from ECPP for out-of-tree builds

### DIFF
--- a/src/rest_srr_GET.ecpp
+++ b/src/rest_srr_GET.ecpp
@@ -24,7 +24,7 @@
  */
  #><%pre>
 
-#include "fty_srr_rest_classes.h"
+#include <src/fty_srr_rest_classes.h>
 
 /**
  * Get SRR capabilities.

--- a/src/rest_srr_reset_POST.ecpp
+++ b/src/rest_srr_reset_POST.ecpp
@@ -24,7 +24,7 @@
  */
  #><%pre>
 
-#include "fty_srr_rest_classes.h"
+#include <src/fty_srr_rest_classes.h>
 
 </%pre>
 <%request scope="global">

--- a/src/rest_srr_restore_POST.ecpp
+++ b/src/rest_srr_restore_POST.ecpp
@@ -24,7 +24,7 @@
  */
  #><%pre>
 
-#include "fty_srr_rest_classes.h"
+#include <src/fty_srr_rest_classes.h>
 
 /**
  * Restore IPM2 configuration data

--- a/src/rest_srr_save_POST.ecpp
+++ b/src/rest_srr_save_POST.ecpp
@@ -24,7 +24,7 @@
  */
  #><%pre>
 
-#include "fty_srr_rest_classes.h"
+#include <src/fty_srr_rest_classes.h>
 
    /**
     * Get IPM2 configuration data from an input list


### PR DESCRIPTION
Similar issue to https://github.com/42ity/fty-security-wallet-rest/pull/17 and https://github.com/42ity/fty-asset-mapping-rest/pull/12