### PR TITLE
Increase timeout to avoid false positive failures

### DIFF
--- a/include/fty-srr-rest.h
+++ b/include/fty-srr-rest.h
@@ -31,6 +31,6 @@
 #define AGENT_NAME                      "fty-srr-rest"
 #define AGENT_NAME_REQUEST_DESTINATION  "fty-srr"
 #define MSG_QUEUE_NAME                  "ETN.Q.IPMCORE.SRR"
-#define DEFAULT_TIME_OUT                120
+#define DEFAULT_TIME_OUT                600
 
 #endif

--- a/include/fty-srr-rest.h
+++ b/include/fty-srr-rest.h
@@ -31,6 +31,6 @@
 #define AGENT_NAME                      "fty-srr-rest"
 #define AGENT_NAME_REQUEST_DESTINATION  "fty-srr"
 #define MSG_QUEUE_NAME                  "ETN.Q.IPMCORE.SRR"
-#define DEFAULT_TIME_OUT                70
+#define DEFAULT_TIME_OUT                120
 
 #endif

--- a/src/rest_srr_restore_POST.ecpp
+++ b/src/rest_srr_restore_POST.ecpp
@@ -88,7 +88,7 @@ UserInfo user;
     }
     catch (std::runtime_error& ex)
     {
-        http_die ("internal-error", TRANSLATE_ME ("SrrException on save IPM2").c_str());
+        http_die ("internal-error", TRANSLATE_ME ("SrrException on restore IPM2").c_str());
     }
     
 </%cpp>


### PR DESCRIPTION
Switch from 70 seconds to 120 seconds.
Also fix an erroneous 'save' instead of 'restore' in logs

Signed-off-by: Arnaud Quette <ArnaudQuette@eaton.com>
(cherry picked from commit 4608b84b572b7b5aa046933318ae23d2ec61894c)

Ref: IPMVAL-2499